### PR TITLE
fix: improve YAML serialization by removing empty objects and keys

### DIFF
--- a/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
+++ b/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
@@ -42,9 +42,9 @@ public partial class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where 
 
     string yaml = _serializer.Serialize(model);
     yaml = EmptyObjectRegex().Replace(yaml, string.Empty);
-    yaml = yaml.TrimEnd(Environment.NewLine.ToCharArray());
+    yaml = yaml.TrimEnd();
     yaml = EmptyObjectKeyRegex().Replace(yaml, "$1 {}");
-    yaml = yaml.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine, StringComparison.Ordinal);
+    yaml = NewLineRegex().Replace(yaml, "\r\n");
     await YamlFileWriter.WriteToFileAsync(outputPath, yaml, overwrite, cancellationToken).ConfigureAwait(false);
   }
 
@@ -53,4 +53,7 @@ public partial class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where 
 
   [GeneratedRegex(@"^(\s*\w+\s*:\s*)(?![\r\n]+[-]*\s+)$", RegexOptions.Multiline)]
   private static partial Regex EmptyObjectKeyRegex();
+
+  [GeneratedRegex(@"(\r\n|\r|\n)+", RegexOptions.Multiline)]
+  private static partial Regex NewLineRegex();
 }

--- a/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
+++ b/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Devantler.KubernetesGenerator.Core.Converters;
 using Devantler.KubernetesGenerator.Core.Inspectors;
 using YamlDotNet.Serialization;
@@ -11,7 +12,7 @@ namespace Devantler.KubernetesGenerator.Core;
 /// A base class for Kubernetes generators.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where T : class
+public partial class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where T : class
 {
   readonly ISerializer _serializer = new SerializerBuilder()
     .DisableAliases()
@@ -40,7 +41,16 @@ public class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where T : clas
     }
 
     string yaml = _serializer.Serialize(model);
-
+    yaml = EmptyObjectRegex().Replace(yaml, string.Empty);
+    yaml = yaml.TrimEnd(Environment.NewLine.ToCharArray());
+    yaml = EmptyObjectKeyRegex().Replace(yaml, "$1 {}");
+    yaml = yaml.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine, StringComparison.Ordinal);
     await YamlFileWriter.WriteToFileAsync(outputPath, yaml, overwrite, cancellationToken).ConfigureAwait(false);
   }
+
+  [GeneratedRegex(@"^\s*\w+\s*:\s*{\s*}\s*$", RegexOptions.Multiline)]
+  private static partial Regex EmptyObjectRegex();
+
+  [GeneratedRegex(@"^(\s*\w+\s*:\s*)(?![\r\n]+[-]*\s+)$", RegexOptions.Multiline)]
+  private static partial Regex EmptyObjectKeyRegex();
 }

--- a/tests/Devantler.KubernetesGenerator.CertManager.Tests/CertManagerClusterIssuerGeneratorTests/cert-manager-cluster-issuer.yaml.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.CertManager.Tests/CertManagerClusterIssuerGeneratorTests/cert-manager-cluster-issuer.yaml.verified.yaml
@@ -4,5 +4,4 @@ kind: ClusterIssuer
 metadata:
   name: cluster-issuer
   namespace: default
-spec:
-  selfSigned: {}
+spec: {}

--- a/tests/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/k3d.full.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/k3d.full.verified.yaml
@@ -82,7 +82,6 @@ options:
     - label: foo=bar
       nodeFilters:
       - agent:1
-  kubeconfig: {}
   runtime:
     gPURequest: all
     labels:

--- a/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind.full.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind.full.verified.yaml
@@ -2,7 +2,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-advanced
-featureGates: {}
 runtimeConfig:
   api/alpha: false
 networking:


### PR DESCRIPTION
Enhance YAML serialization by eliminating empty objects and keys, resulting in cleaner output. This change improves the overall efficiency of the serialization process.