### PR TITLE
feat: implement comment gathering for YAML serialization

### DIFF
--- a/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
+++ b/src/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
@@ -16,11 +16,11 @@ public partial class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where 
 {
   readonly ISerializer _serializer = new SerializerBuilder()
     .DisableAliases()
-    .WithTypeInspector(inner => new KubernetesTypeInspector(new SystemTextJsonTypeInspector(inner)))
+    .WithTypeInspector(inner => new CommentGatheringTypeInspector(new KubernetesTypeInspector(new SystemTextJsonTypeInspector(inner))))
     .WithTypeConverter(new IntstrIntOrStringTypeConverter())
     .WithTypeConverter(new ResourceQuantityTypeConverter())
     .WithTypeConverter(new ByteArrayTypeConverter())
-    .WithEmissionPhaseObjectGraphVisitor(inner => new KubernetesObjectGraphVisitor<T>(inner.InnerVisitor, Activator.CreateInstance<T>()))
+    .WithEmissionPhaseObjectGraphVisitor(inner => new CommentsObjectGraphVisitor(new KubernetesObjectGraphVisitor<T>(inner.InnerVisitor, Activator.CreateInstance<T>())))
     .WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
 
   /// <summary>

--- a/src/Devantler.KubernetesGenerator.Core/CommentGatheringTypeInspector.cs
+++ b/src/Devantler.KubernetesGenerator.Core/CommentGatheringTypeInspector.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.TypeInspectors;
+
+namespace Devantler.KubernetesGenerator.Core;
+
+
+/// <summary>
+/// A type inspector that gathers comments from properties and adds them to the YAML output.
+/// </summary>
+public class CommentGatheringTypeInspector : TypeInspectorSkeleton
+{
+  private readonly ITypeInspector _innerTypeDescriptor;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="CommentGatheringTypeInspector"/> class.
+  /// </summary>
+  /// <param name="innerTypeDescriptor"></param>
+  public CommentGatheringTypeInspector(ITypeInspector innerTypeDescriptor)
+  {
+    ArgumentNullException.ThrowIfNull(innerTypeDescriptor);
+
+    _innerTypeDescriptor = innerTypeDescriptor;
+  }
+
+  /// <summary>
+  /// Gets the name of the specified enum.
+  /// </summary>
+  /// <param name="enumType"></param>
+  /// <param name="name"></param>
+  /// <returns></returns>
+  /// <exception cref="NotImplementedException"></exception>
+  public override string GetEnumName(Type enumType, string name) => _innerTypeDescriptor.GetEnumName(enumType, name);
+
+  /// <summary>
+  /// Gets the value of the specified enum enum.
+  /// </summary>
+  /// <param name="enumValue"></param>
+  /// <returns></returns>
+  /// <exception cref="NotImplementedException"></exception>
+  public override string GetEnumValue(object enumValue) => _innerTypeDescriptor.GetEnumValue(enumValue);
+
+  /// <summary>
+  /// Gets the properties of the specified type and container.
+  /// </summary>
+  /// <param name="type"></param>
+  /// <param name="container"></param>
+  /// <returns></returns>
+  public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
+  {
+    return _innerTypeDescriptor
+      .GetProperties(type, container)
+      .Select(d => new CommentsPropertyDescriptor(d));
+  }
+
+  private sealed class CommentsPropertyDescriptor(IPropertyDescriptor baseDescriptor) : IPropertyDescriptor
+  {
+    private readonly IPropertyDescriptor _baseDescriptor = baseDescriptor;
+
+    public string Name { get; set; } = baseDescriptor.Name;
+
+    public Type Type { get { return _baseDescriptor.Type; } }
+
+    public Type? TypeOverride
+    {
+      get => _baseDescriptor.TypeOverride; set => _baseDescriptor.TypeOverride = value;
+    }
+
+    public int Order { get; set; }
+
+    public ScalarStyle ScalarStyle
+    {
+      get { return _baseDescriptor.ScalarStyle; }
+      set { _baseDescriptor.ScalarStyle = value; }
+    }
+
+    public bool CanWrite { get { return _baseDescriptor.CanWrite; } }
+
+    public bool AllowNulls => _baseDescriptor.AllowNulls;
+
+    ScalarStyle IPropertyDescriptor.ScalarStyle { get => _baseDescriptor.ScalarStyle; set => _baseDescriptor.ScalarStyle = value; }
+    public bool Required => _baseDescriptor.Required;
+
+    public Type? ConverterType => _baseDescriptor.ConverterType;
+
+    public void Write(object target, object? value) => _baseDescriptor.Write(target, value);
+
+    public T GetCustomAttribute<T>() where T : Attribute => _baseDescriptor.GetCustomAttribute<T>()!;
+
+    public IObjectDescriptor Read(object target)
+    {
+      var description = _baseDescriptor.GetCustomAttribute<DescriptionAttribute>();
+      return description != null
+        ? new CommentsObjectDescriptor(_baseDescriptor.Read(target), description.Description)
+        : _baseDescriptor.Read(target);
+    }
+  }
+}

--- a/src/Devantler.KubernetesGenerator.Core/CommentsObjectDescriptor.cs
+++ b/src/Devantler.KubernetesGenerator.Core/CommentsObjectDescriptor.cs
@@ -1,0 +1,43 @@
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace Devantler.KubernetesGenerator.Core;
+
+
+/// <summary>
+/// A descriptor for objects that includes comments for YAML serialization.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="CommentsObjectDescriptor"/> class.
+/// </remarks>
+/// <param name="innerDescriptor"></param>
+/// <param name="comment"></param>
+public sealed class CommentsObjectDescriptor(IObjectDescriptor innerDescriptor, string comment) : IObjectDescriptor
+{
+  private readonly IObjectDescriptor _innerDescriptor = innerDescriptor;
+
+  /// <summary>
+  /// Gets the comment associated with the object descriptor.
+  /// </summary>
+  public string Comment { get; private set; } = comment;
+
+  /// <summary>
+  /// Gets the value of the object descriptor.
+  /// </summary>
+  public object? Value => _innerDescriptor.Value;
+
+  /// <summary>
+  /// Gets the type of the object descriptor.
+  /// </summary>
+  public Type Type { get { return _innerDescriptor.Type; } }
+
+  /// <summary>
+  /// Gets the static type of the object descriptor.
+  /// </summary>
+  public Type StaticType { get { return _innerDescriptor.StaticType; } }
+
+  /// <summary>
+  /// Gets the scalar style of the object descriptor.
+  /// </summary>
+  public ScalarStyle ScalarStyle { get { return _innerDescriptor.ScalarStyle; } }
+}

--- a/src/Devantler.KubernetesGenerator.Core/CommentsObjectGraphVisitor.cs
+++ b/src/Devantler.KubernetesGenerator.Core/CommentsObjectGraphVisitor.cs
@@ -1,0 +1,33 @@
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.ObjectGraphVisitors;
+
+namespace Devantler.KubernetesGenerator.Core;
+
+
+/// <summary>
+/// An object graph visitor that adds comments to the YAML output.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="CommentsObjectGraphVisitor"/> class.
+/// </remarks>
+/// <param name="nextVisitor"></param>
+public class CommentsObjectGraphVisitor(IObjectGraphVisitor<IEmitter> nextVisitor) : ChainedObjectGraphVisitor(nextVisitor)
+{
+  /// <summary>
+  /// Enters a mapping in the object graph and emits a comment if the value is a <see cref="CommentsObjectDescriptor"/>.
+  /// </summary>
+  /// <param name="key"></param>
+  /// <param name="value"></param>
+  /// <param name="context"></param>
+  /// <param name="serializer"></param>
+  /// <returns></returns>
+  public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context, ObjectSerializer serializer)
+  {
+    ArgumentNullException.ThrowIfNull(context);
+    if (value is CommentsObjectDescriptor commentsDescriptor && commentsDescriptor.Comment != null)
+      context.Emit(new Comment(commentsDescriptor.Comment, false));
+    return base.EnterMapping(key, value, context, serializer);
+  }
+}

--- a/src/Devantler.KubernetesGenerator.K3d/Models/K3dConfig.cs
+++ b/src/Devantler.KubernetesGenerator.K3d/Models/K3dConfig.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Devantler.KubernetesGenerator.K3d.Models.Options;
 using Devantler.KubernetesGenerator.K3d.Models.Registries;
 using k8s.Models;


### PR DESCRIPTION
Introduce a new type inspector and object graph visitor to gather comments from properties and include them in the YAML output. This enhancement improves the serialization process by preserving comments associated with properties.