### PR TITLE
fix: update KubeadmConfigPatches to use IEnumerable<string> in KindNode model and tests

### DIFF
--- a/src/Devantler.KubernetesGenerator.Kind/Models/Nodes/KindNode.cs
+++ b/src/Devantler.KubernetesGenerator.Kind/Models/Nodes/KindNode.cs
@@ -33,5 +33,5 @@ public class KindNode
   /// <summary>
   /// Kubeadm configuration patches to apply to the node.
   /// </summary>
-  public string KubeadmConfigPatches { get; set; } = "";
+  public IEnumerable<string> KubeadmConfigPatches { get; set; } = [];
 }

--- a/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/GenerateAsyncTests.cs
+++ b/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/GenerateAsyncTests.cs
@@ -63,7 +63,7 @@ public class GenerateAsyncTests
           KindNodeLabels = {
             { "node-role.kubernetes.io/master", "" }
           },
-          KubeadmConfigPatches = ""
+          KubeadmConfigPatches = [""]
         },
         new KindNode {
           Role = KindNodeRole.Worker,
@@ -89,7 +89,7 @@ public class GenerateAsyncTests
           KindNodeLabels = {
             { "node-role.kubernetes.io/worker", "" }
           },
-          KubeadmConfigPatches = ""
+          KubeadmConfigPatches = [""]
         }
       ],
       ContainerdConfigPatches = [

--- a/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind.full.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind.full.verified.yaml
@@ -29,7 +29,8 @@ nodes:
     protocol: TCP
   kindNodeLabels:
     node-role.kubernetes.io/master: ''
-  kubeadmConfigPatches: ''
+  kubeadmConfigPatches:
+  - ''
 - role: Worker
   image: kindest/node:v1.32.1
   extraMounts:
@@ -45,7 +46,8 @@ nodes:
     protocol: TCP
   kindNodeLabels:
     node-role.kubernetes.io/worker: ''
-  kubeadmConfigPatches: ''
+  kubeadmConfigPatches:
+  - ''
 containerdConfigPatches:
 - >-
   [plugins."io.containerd.grpc.v1.cri".registry]


### PR DESCRIPTION
Change KubeadmConfigPatches from a string to an IEnumerable<string> to improve flexibility in handling configuration patches. Update related tests to reflect this change.