### PR TITLE
fix: Require name in constructor for DockerRegistrySecret and TLSSecret

### DIFF
--- a/src/DevantlerTech.KubernetesGenerator.Native/DockerRegistrySecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/DockerRegistrySecretGenerator.cs
@@ -37,19 +37,15 @@ public class DockerRegistrySecretGenerator : BaseNativeGenerator<DockerRegistryS
   /// <returns>The kubectl arguments.</returns>
   static ReadOnlyCollection<string> AddOptions(DockerRegistrySecret model)
   {
-    var args = new List<string> { };
-
-    // Require that a secret name is provided
-    if (string.IsNullOrEmpty(model.Metadata?.Name))
+    var args = new List<string>
     {
-      throw new KubernetesGeneratorException("The model.Metadata.Name must be set to set the secret name.");
-    }
-    args.Add(model.Metadata.Name);
+      model.Metadata.Name
+    };
 
     // Add namespace if specified
-    if (!string.IsNullOrEmpty(model.Metadata?.NamespaceProperty))
+    if (!string.IsNullOrEmpty(model.Metadata.Namespace))
     {
-      args.Add($"--namespace={model.Metadata.NamespaceProperty}");
+      args.Add($"--namespace={model.Metadata.Namespace}");
     }
 
     // Add Docker registry specific arguments

--- a/src/DevantlerTech.KubernetesGenerator.Native/Models/DockerRegistrySecret.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/Models/DockerRegistrySecret.cs
@@ -1,16 +1,14 @@
-using k8s.Models;
-
 namespace DevantlerTech.KubernetesGenerator.Native.Models;
 
 /// <summary>
 /// Represents a Docker registry secret for use with kubectl create secret docker-registry.
 /// </summary>
-public class DockerRegistrySecret
+public class DockerRegistrySecret(string name)
 {
   /// <summary>
   /// Gets or sets the metadata for the secret.
   /// </summary>
-  public V1ObjectMeta? Metadata { get; set; }
+  public Metadata Metadata { get; set; } = new() { Name = name };
 
   /// <summary>
   /// Gets or sets the Docker registry server URL.

--- a/src/DevantlerTech.KubernetesGenerator.Native/Models/TLSSecret.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/Models/TLSSecret.cs
@@ -1,16 +1,14 @@
-using k8s.Models;
-
 namespace DevantlerTech.KubernetesGenerator.Native.Models;
 
 /// <summary>
 /// Represents a TLS secret for use with kubectl create secret tls.
 /// </summary>
-public class TLSSecret
+public class TLSSecret(string name)
 {
   /// <summary>
   /// Gets or sets the metadata for the secret.
   /// </summary>
-  public V1ObjectMeta? Metadata { get; set; }
+  public Metadata Metadata { get; set; } = new() { Name = name };
 
   /// <summary>
   /// Gets or sets the certificate data, either as a file path or the certificate content.

--- a/src/DevantlerTech.KubernetesGenerator.Native/TLSSecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/TLSSecretGenerator.cs
@@ -45,19 +45,15 @@ public class TLSSecretGenerator : BaseNativeGenerator<TLSSecret>
   /// <returns>The kubectl arguments.</returns>
   async Task<ReadOnlyCollection<string>> AddOptionsAsync(TLSSecret model, CancellationToken cancellationToken = default)
   {
-    var args = new List<string> { };
-
-    // Require that a secret name is provided
-    if (string.IsNullOrEmpty(model.Metadata?.Name))
+    var args = new List<string>
     {
-      throw new KubernetesGeneratorException("The model.Metadata.Name must be set to set the secret name.");
-    }
-    args.Add(model.Metadata.Name);
+      model.Metadata.Name
+    };
 
     // Add namespace if specified
-    if (!string.IsNullOrEmpty(model.Metadata?.NamespaceProperty))
+    if (!string.IsNullOrEmpty(model.Metadata.Namespace))
     {
-      args.Add($"--namespace={model.Metadata.NamespaceProperty}");
+      args.Add($"--namespace={model.Metadata.Namespace}");
     }
 
     // Handle certificate and key data

--- a/tests/DevantlerTech.KubernetesGenerator.Native.Tests/DockerRegistrySecretGeneratorTests/GenerateAsyncTests.cs
+++ b/tests/DevantlerTech.KubernetesGenerator.Native.Tests/DockerRegistrySecretGeneratorTests/GenerateAsyncTests.cs
@@ -1,6 +1,4 @@
-using DevantlerTech.KubernetesGenerator.Core;
 using DevantlerTech.KubernetesGenerator.Native.Models;
-using k8s.Models;
 
 namespace DevantlerTech.KubernetesGenerator.Native.Tests.DockerRegistrySecretGeneratorTests;
 
@@ -18,18 +16,14 @@ public sealed class GenerateAsyncTests
   {
     // Arrange
     var generator = new DockerRegistrySecretGenerator();
-    var model = new DockerRegistrySecret
+    var model = new DockerRegistrySecret("docker-registry-secret")
     {
-      Metadata = new V1ObjectMeta
-      {
-        Name = "docker-registry-secret",
-        NamespaceProperty = "default"
-      },
       DockerServer = "https://index.docker.io/v1/",
       DockerUsername = "myuser",
       DockerPassword = "mypassword",
       DockerEmail = "myuser@example.com"
     };
+    model.Metadata.Namespace = "default";
 
     // Act
     string fileName = "docker-registry-secret.yaml";
@@ -55,12 +49,8 @@ public sealed class GenerateAsyncTests
   {
     // Arrange
     var generator = new DockerRegistrySecretGenerator();
-    var model = new DockerRegistrySecret
+    var model = new DockerRegistrySecret("docker-registry-secret-minimal")
     {
-      Metadata = new V1ObjectMeta
-      {
-        Name = "docker-registry-secret-minimal"
-      },
       DockerUsername = "user",
       DockerPassword = "pass",
       DockerEmail = "user@example.com"
@@ -79,29 +69,5 @@ public sealed class GenerateAsyncTests
 
     // Cleanup
     File.Delete(outputPath);
-  }
-
-  /// <summary>
-  /// Verifies that a <see cref="KubernetesGeneratorException"/> is thrown when the DockerRegistrySecret model does not have a name set.
-  /// </summary>
-  [Fact]
-  public async Task GenerateAsync_WithDockerRegistrySecretWithoutName_ShouldThrowKubernetesGeneratorException()
-  {
-    // Arrange
-    var generator = new DockerRegistrySecretGenerator();
-
-    var model = new DockerRegistrySecret
-    {
-      Metadata = new V1ObjectMeta
-      {
-        NamespaceProperty = "default"
-      },
-      DockerEmail = "myuser@example.com",
-      DockerUsername = "myuser",
-      DockerPassword = "mypassword"
-    };
-
-    // Act & Assert
-    _ = await Assert.ThrowsAsync<KubernetesGeneratorException>(() => generator.GenerateAsync(model, Path.GetTempFileName()));
   }
 }

--- a/tests/DevantlerTech.KubernetesGenerator.Native.Tests/TLSSecretGeneratorTests/GenerateAsyncTests.cs
+++ b/tests/DevantlerTech.KubernetesGenerator.Native.Tests/TLSSecretGeneratorTests/GenerateAsyncTests.cs
@@ -1,6 +1,5 @@
 using DevantlerTech.KubernetesGenerator.Core;
 using DevantlerTech.KubernetesGenerator.Native.Models;
-using k8s.Models;
 
 namespace DevantlerTech.KubernetesGenerator.Native.Tests.TLSSecretGeneratorTests;
 
@@ -22,16 +21,12 @@ public sealed class GenerateAsyncTests
     string privateKeyContent = await File.ReadAllTextAsync(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tls.key"));
 
     var generator = new TLSSecretGenerator();
-    var model = new TLSSecret
+    var model = new TLSSecret("tls-secret-content")
     {
-      Metadata = new V1ObjectMeta
-      {
-        Name = "tls-secret-content",
-        NamespaceProperty = "default"
-      },
       Certificate = certificateContent,
       PrivateKey = privateKeyContent
     };
+    model.Metadata.Namespace = "default";
 
     // Act
     string fileName = "tls-secret-content.yaml";
@@ -68,16 +63,12 @@ public sealed class GenerateAsyncTests
     // Arrange
     var generator = new TLSSecretGenerator();
 
-    var model = new TLSSecret
+    var model = new TLSSecret("tls-secret-files")
     {
-      Metadata = new V1ObjectMeta
-      {
-        Name = "tls-secret-files",
-        NamespaceProperty = "default"
-      },
       Certificate = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tls.crt"),
       PrivateKey = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tls.key")
     };
+    model.Metadata.Namespace = "default";
 
     // Act
     string fileName = "tls-secret-files.yaml";
@@ -97,30 +88,6 @@ public sealed class GenerateAsyncTests
     File.Delete(outputPath);
   }
 
-  // Add a test that tests that the throw new KubernetesGeneratorException("The model.Metadata.Name must be set to set the secret name."); is thrown when the name is not set
-  /// <summary>
-  /// Verifies that a <see cref="KubernetesGeneratorException"/> is thrown when the TLSSecret model does not have a name set.
-  /// </summary>
-  [Fact]
-  public async Task GenerateAsync_WithTLSSecretWithoutName_ShouldThrowKubernetesGeneratorException()
-  {
-    // Arrange
-    var generator = new TLSSecretGenerator();
-
-    var model = new TLSSecret
-    {
-      Metadata = new V1ObjectMeta
-      {
-        NamespaceProperty = "default"
-      },
-      Certificate = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tls.crt"),
-      PrivateKey = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tls.key")
-    };
-
-    // Act & Assert
-    _ = await Assert.ThrowsAsync<KubernetesGeneratorException>(() => generator.GenerateAsync(model, Path.GetTempFileName()));
-  }
-
 
   /// <summary>
   /// Verifies that a <see cref="KubernetesGeneratorException"/> is thrown when invalid certificate or private key data is provided.
@@ -131,16 +98,12 @@ public sealed class GenerateAsyncTests
     // Arrange
     var generator = new TLSSecretGenerator();
 
-    var model = new TLSSecret
+    var model = new TLSSecret("tls-secret-invalid-cert")
     {
-      Metadata = new V1ObjectMeta
-      {
-        Name = "tls-secret-invalid-cert",
-        NamespaceProperty = "default"
-      },
       Certificate = "invalid-certificate-data",
       PrivateKey = "invalid-private-key-data"
     };
+    model.Metadata.Namespace = "default";
 
     // Act & Assert
     _ = await Assert.ThrowsAsync<KubernetesGeneratorException>(() => generator.GenerateAsync(model, Path.GetTempFileName()));


### PR DESCRIPTION
Refactor DockerRegistrySecret and TLSSecret classes to require a name during instantiation, ensuring that the secret name is always set. Update related tests accordingly.