### PR TITLE
feat: Introduce GenericSecret model and update generator

### DIFF
--- a/src/DevantlerTech.KubernetesGenerator.Native/ClusterIPServiceGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/ClusterIPServiceGenerator.cs
@@ -25,7 +25,7 @@ public class ClusterIPServiceGenerator : ServiceGeneratorBase
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create ClusterIP service '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -36,7 +36,7 @@ public class ClusterIPServiceGenerator : ServiceGeneratorBase
   /// </summary>
   /// <param name="model">The V1Service object.</param>
   /// <returns>The kubectl arguments.</returns>
-  static ReadOnlyCollection<string> AddOptions(V1Service model)
+  static ReadOnlyCollection<string> AddArguments(V1Service model)
   {
     var args = new Collection<string>();
 

--- a/src/DevantlerTech.KubernetesGenerator.Native/DockerRegistrySecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/DockerRegistrySecretGenerator.cs
@@ -24,7 +24,7 @@ public class DockerRegistrySecretGenerator : BaseNativeGenerator<DockerRegistryS
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create Docker registry secret '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -35,7 +35,7 @@ public class DockerRegistrySecretGenerator : BaseNativeGenerator<DockerRegistryS
   /// </summary>
   /// <param name="model">The DockerRegistrySecret object.</param>
   /// <returns>The kubectl arguments.</returns>
-  static ReadOnlyCollection<string> AddOptions(DockerRegistrySecret model)
+  static ReadOnlyCollection<string> AddArguments(DockerRegistrySecret model)
   {
     var args = new List<string>
     {

--- a/src/DevantlerTech.KubernetesGenerator.Native/ExternalNameServiceGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/ExternalNameServiceGenerator.cs
@@ -25,7 +25,7 @@ public class ExternalNameServiceGenerator : ServiceGeneratorBase
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create ExternalName service '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -36,7 +36,7 @@ public class ExternalNameServiceGenerator : ServiceGeneratorBase
   /// </summary>
   /// <param name="model">The V1Service object.</param>
   /// <returns>The kubectl arguments.</returns>
-  static ReadOnlyCollection<string> AddOptions(V1Service model)
+  static ReadOnlyCollection<string> AddArguments(V1Service model)
   {
     var args = new Collection<string>();
 

--- a/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
@@ -24,7 +24,7 @@ public class GenericSecretGenerator : BaseNativeGenerator<GenericSecret>
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create generic secret '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -34,7 +34,7 @@ public class GenericSecretGenerator : BaseNativeGenerator<GenericSecret>
   /// Builds the kubectl arguments for creating a generic secret from a GenericSecret object.
   /// </summary>
   /// <param name="model">The GenericSecret object.</param>
-  static ReadOnlyCollection<string> AddOptions(GenericSecret model)
+  static ReadOnlyCollection<string> AddArguments(GenericSecret model)
   {
     var args = new List<string>
     {

--- a/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
@@ -1,14 +1,13 @@
 using System.Collections.ObjectModel;
-using System.Text;
 using DevantlerTech.KubernetesGenerator.Core;
-using k8s.Models;
+using DevantlerTech.KubernetesGenerator.Native.Models;
 
 namespace DevantlerTech.KubernetesGenerator.Native;
 
 /// <summary>
 /// A generator for generic Kubernetes Secret objects using 'kubectl create secret generic' commands.
 /// </summary>
-public class GenericSecretGenerator : BaseNativeGenerator<V1Secret>
+public class GenericSecretGenerator : BaseNativeGenerator<GenericSecret>
 {
   static readonly string[] _defaultArgs = ["create", "secret", "generic"];
   /// <summary>
@@ -20,7 +19,7 @@ public class GenericSecretGenerator : BaseNativeGenerator<V1Secret>
   /// <param name="cancellationToken">The cancellation token.</param>
   /// <exception cref="ArgumentNullException">Thrown when model is null.</exception>
   /// <exception cref="KubernetesGeneratorException">Thrown when secret name is not provided.</exception>
-  public override async Task GenerateAsync(V1Secret model, string outputPath, bool overwrite = false, CancellationToken cancellationToken = default)
+  public override async Task GenerateAsync(GenericSecret model, string outputPath, bool overwrite = false, CancellationToken cancellationToken = default)
   {
     ArgumentNullException.ThrowIfNull(model);
 
@@ -32,19 +31,16 @@ public class GenericSecretGenerator : BaseNativeGenerator<V1Secret>
   }
 
   /// <summary>
-  /// Builds the kubectl arguments for creating a generic secret from a V1Secret object.
+  /// Builds the kubectl arguments for creating a generic secret from a GenericSecret object.
   /// </summary>
-  /// <param name="model">The V1Secret object.</param>
-  static ReadOnlyCollection<string> AddOptions(V1Secret model)
+  /// <param name="model">The GenericSecret object.</param>
+  static ReadOnlyCollection<string> AddOptions(GenericSecret model)
   {
-    var args = new List<string> { };
-
-    // Require that a secret name is provided
-    if (string.IsNullOrEmpty(model.Metadata?.Name))
+    var args = new List<string>
     {
-      throw new KubernetesGeneratorException("The model.Metadata.Name must be set to set the secret name.");
-    }
-    args.Add(model.Metadata.Name);
+      // The secret name is always available from the metadata (required in constructor)
+      model.Metadata.Name
+    };
 
     // Add type if specified (but don't require it)
     if (!string.IsNullOrEmpty(model.Type))
@@ -52,38 +48,16 @@ public class GenericSecretGenerator : BaseNativeGenerator<V1Secret>
       args.Add($"--type={model.Type}");
     }
 
-    // Combine data from both Data and StringData, with StringData taking precedence
-    var combinedData = new Dictionary<string, string>();
-
-    // First add data from Data (base64 decoded)
-    if (model.Data?.Count > 0)
-    {
-      foreach (var kvp in model.Data)
-      {
-        string value = Encoding.UTF8.GetString(kvp.Value);
-        combinedData[kvp.Key] = value;
-      }
-    }
-
-    // Then add/override with StringData (takes precedence)
-    if (model.StringData?.Count > 0)
-    {
-      foreach (var kvp in model.StringData)
-      {
-        combinedData[kvp.Key] = kvp.Value;
-      }
-    }
-
-    // Add all combined data as literals
-    foreach (var kvp in combinedData)
+    // Add all data as literals
+    foreach (var kvp in model.Data)
     {
       args.Add($"--from-literal={kvp.Key}={kvp.Value}");
     }
 
     // Add namespace if specified
-    if (!string.IsNullOrEmpty(model.Metadata?.NamespaceProperty))
+    if (!string.IsNullOrEmpty(model.Metadata?.Namespace))
     {
-      args.Add($"--namespace={model.Metadata.NamespaceProperty}");
+      args.Add($"--namespace={model.Metadata.Namespace}");
     }
 
     return args.AsReadOnly();

--- a/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/GenericSecretGenerator.cs
@@ -42,6 +42,12 @@ public class GenericSecretGenerator : BaseNativeGenerator<GenericSecret>
       model.Metadata.Name
     };
 
+    // Add namespace if specified
+    if (!string.IsNullOrEmpty(model.Metadata.Namespace))
+    {
+      args.Add($"--namespace={model.Metadata.Namespace}");
+    }
+
     // Add type if specified (but don't require it)
     if (!string.IsNullOrEmpty(model.Type))
     {
@@ -52,12 +58,6 @@ public class GenericSecretGenerator : BaseNativeGenerator<GenericSecret>
     foreach (var kvp in model.Data)
     {
       args.Add($"--from-literal={kvp.Key}={kvp.Value}");
-    }
-
-    // Add namespace if specified
-    if (!string.IsNullOrEmpty(model.Metadata?.Namespace))
-    {
-      args.Add($"--namespace={model.Metadata.Namespace}");
     }
 
     return args.AsReadOnly();

--- a/src/DevantlerTech.KubernetesGenerator.Native/LoadBalancerServiceGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/LoadBalancerServiceGenerator.cs
@@ -25,7 +25,7 @@ public class LoadBalancerServiceGenerator : ServiceGeneratorBase
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create LoadBalancer service '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -36,7 +36,7 @@ public class LoadBalancerServiceGenerator : ServiceGeneratorBase
   /// </summary>
   /// <param name="model">The V1Service object.</param>
   /// <returns>The kubectl arguments.</returns>
-  static ReadOnlyCollection<string> AddOptions(V1Service model)
+  static ReadOnlyCollection<string> AddArguments(V1Service model)
   {
     var args = new Collection<string>();
 

--- a/src/DevantlerTech.KubernetesGenerator.Native/Models/GenericSecret.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/Models/GenericSecret.cs
@@ -1,0 +1,22 @@
+namespace DevantlerTech.KubernetesGenerator.Native.Models;
+
+/// <summary>
+/// Represents a generic secret for use with kubectl create secret generic.
+/// </summary>
+public class GenericSecret(string name)
+{
+  /// <summary>
+  /// Gets or sets the metadata for the secret.
+  /// </summary>
+  public Metadata Metadata { get; set; } = new() { Name = name };
+
+  /// <summary>
+  /// Gets or sets the secret type. If not specified, defaults to 'Opaque'.
+  /// </summary>
+  public string? Type { get; set; }
+
+  /// <summary>
+  /// Gets the secret data as key-value pairs.
+  /// </summary>
+  public Dictionary<string, string> Data { get; } = [];
+}

--- a/src/DevantlerTech.KubernetesGenerator.Native/NodePortServiceGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/NodePortServiceGenerator.cs
@@ -25,7 +25,7 @@ public class NodePortServiceGenerator : ServiceGeneratorBase
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create NodePort service '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -36,7 +36,7 @@ public class NodePortServiceGenerator : ServiceGeneratorBase
   /// </summary>
   /// <param name="model">The V1Service object.</param>
   /// <returns>The kubectl arguments.</returns>
-  static ReadOnlyCollection<string> AddOptions(V1Service model)
+  static ReadOnlyCollection<string> AddArguments(V1Service model)
   {
     var args = new Collection<string>();
 

--- a/src/DevantlerTech.KubernetesGenerator.Native/RoleBindingGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/RoleBindingGenerator.cs
@@ -25,7 +25,7 @@ public class RoleBindingGenerator : BaseNativeGenerator<RoleBinding>
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create role binding '{model.Metadata.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -37,7 +37,7 @@ public class RoleBindingGenerator : BaseNativeGenerator<RoleBinding>
   /// <param name="model">The RoleBinding object.</param>
   /// <returns>The kubectl arguments.</returns>
   /// <exception cref="KubernetesGeneratorException">Thrown when required properties are missing.</exception>
-  static ReadOnlyCollection<string> AddOptions(RoleBinding model)
+  static ReadOnlyCollection<string> AddArguments(RoleBinding model)
   {
     List<string> args = [];
 

--- a/src/DevantlerTech.KubernetesGenerator.Native/ServiceAccountGenerator.cs
+++ b/src/DevantlerTech.KubernetesGenerator.Native/ServiceAccountGenerator.cs
@@ -25,7 +25,7 @@ public class ServiceAccountGenerator : BaseNativeGenerator<V1ServiceAccount>
     ArgumentNullException.ThrowIfNull(model);
 
     var args = new ReadOnlyCollection<string>(
-      [.. _defaultArgs, .. AddOptions(model)]
+      [.. _defaultArgs, .. AddArguments(model)]
     );
     string errorMessage = $"Failed to create service account '{model.Metadata?.Name}' using kubectl";
     await RunKubectlAsync(outputPath, overwrite, args, errorMessage, cancellationToken).ConfigureAwait(false);
@@ -41,7 +41,7 @@ public class ServiceAccountGenerator : BaseNativeGenerator<V1ServiceAccount>
   /// Advanced properties like ImagePullSecrets, AutomountServiceAccountToken, and Secrets are not supported
   /// by the kubectl create command and will be ignored.
   /// </remarks>
-  static ReadOnlyCollection<string> AddOptions(V1ServiceAccount model)
+  static ReadOnlyCollection<string> AddArguments(V1ServiceAccount model)
   {
     var args = new List<string> { };
 

--- a/tests/DevantlerTech.KubernetesGenerator.Native.Tests/GenericSecretGeneratorTests/GenerateAsyncTests.cs
+++ b/tests/DevantlerTech.KubernetesGenerator.Native.Tests/GenericSecretGeneratorTests/GenerateAsyncTests.cs
@@ -1,5 +1,4 @@
-using DevantlerTech.KubernetesGenerator.Core;
-using k8s.Models;
+using DevantlerTech.KubernetesGenerator.Native.Models;
 
 namespace DevantlerTech.KubernetesGenerator.Native.Tests.GenericSecretGeneratorTests;
 
@@ -9,7 +8,7 @@ namespace DevantlerTech.KubernetesGenerator.Native.Tests.GenericSecretGeneratorT
 public sealed class GenerateAsyncTests
 {
   /// <summary>
-  /// Verifies the generated generic Secret object using V1Secret input.
+  /// Verifies the generated generic Secret object using GenericSecret input.
   /// </summary>
   /// <returns></returns>
   [Fact]
@@ -17,22 +16,13 @@ public sealed class GenerateAsyncTests
   {
     // Arrange
     var generator = new GenericSecretGenerator();
-    var model = new V1Secret
+    var model = new GenericSecret("generic-secret")
     {
-      ApiVersion = "v1",
-      Kind = "Secret",
-      Metadata = new V1ObjectMeta
-      {
-        Name = "generic-secret",
-        NamespaceProperty = "default"
-      },
-      Type = "Opaque",
-      StringData = new Dictionary<string, string>
-      {
-        ["key1"] = "value1",
-        ["key2"] = "value2"
-      }
+      Metadata = { Namespace = "default" },
+      Type = "Opaque"
     };
+    model.Data.Add("key1", "value1");
+    model.Data.Add("key2", "value2");
 
     // Act
     string fileName = "generic-secret.yaml";
@@ -58,20 +48,11 @@ public sealed class GenerateAsyncTests
   {
     // Arrange
     var generator = new GenericSecretGenerator();
-    var model = new V1Secret
+    var model = new GenericSecret("generic-secret-no-type")
     {
-      ApiVersion = "v1",
-      Kind = "Secret",
-      Metadata = new V1ObjectMeta
-      {
-        Name = "generic-secret-no-type",
-        NamespaceProperty = "default"
-      },
-      StringData = new Dictionary<string, string>
-      {
-        ["key1"] = "value1"
-      }
+      Metadata = { Namespace = "default" }
     };
+    model.Data.Add("key1", "value1");
 
     // Act
     string fileName = "generic-secret-no-type.yaml";
@@ -89,7 +70,7 @@ public sealed class GenerateAsyncTests
   }
 
   /// <summary>
-  /// Verifies the generated generic Secret object with both Data and StringData.
+  /// Verifies the generated generic Secret object with mixed data.
   /// </summary>
   /// <returns></returns>
   [Fact]
@@ -97,27 +78,14 @@ public sealed class GenerateAsyncTests
   {
     // Arrange
     var generator = new GenericSecretGenerator();
-    var model = new V1Secret
+    var model = new GenericSecret("generic-secret-mixed")
     {
-      ApiVersion = "v1",
-      Kind = "Secret",
-      Metadata = new V1ObjectMeta
-      {
-        Name = "generic-secret-mixed",
-        NamespaceProperty = "default"
-      },
-      Type = "Opaque",
-      Data = new Dictionary<string, byte[]>
-      {
-        ["data-key"] = "data-value"u8.ToArray(),
-        ["override-key"] = "data-override"u8.ToArray()
-      },
-      StringData = new Dictionary<string, string>
-      {
-        ["string-key"] = "string-value",
-        ["override-key"] = "string-override"
-      }
+      Metadata = { Namespace = "default" },
+      Type = "Opaque"
     };
+    model.Data.Add("data-key", "data-value");
+    model.Data.Add("string-key", "string-value");
+    model.Data.Add("override-key", "string-override");
 
     // Act
     string fileName = "generic-secret-mixed.yaml";
@@ -135,21 +103,15 @@ public sealed class GenerateAsyncTests
   }
 
   /// <summary>
-  /// Verifies that a <see cref="KubernetesGeneratorException"/> is thrown when the model does not have a name set.
+  /// Verifies that a <see cref="ArgumentNullException"/> is thrown when the model is null.
   /// </summary>
   [Fact]
-  public async Task GenerateAsync_WithDockerRegistrySecretWithoutName_ShouldThrowKubernetesGeneratorException()
+  public async Task GenerateAsync_WithNullModel_ShouldThrowArgumentNullException()
   {
     // Arrange
     var generator = new GenericSecretGenerator();
 
-    var model = new V1Secret
-    {
-      ApiVersion = "v1",
-      Kind = "Secret"
-    };
-
     // Act & Assert
-    _ = await Assert.ThrowsAsync<KubernetesGeneratorException>(() => generator.GenerateAsync(model, Path.GetTempFileName()));
+    _ = await Assert.ThrowsAsync<ArgumentNullException>(() => generator.GenerateAsync(null!, Path.GetTempFileName()));
   }
 }


### PR DESCRIPTION
Introduce a new GenericSecret model to streamline the creation of Kubernetes secrets. Update the GenericSecretGenerator to utilize this new model, enhancing the generation process and simplifying the handling of secret data.